### PR TITLE
Handle responsefile arguments

### DIFF
--- a/tools/ld.musl-clang.in
+++ b/tools/ld.musl-clang.in
@@ -7,6 +7,11 @@ shared=
 userlinkdir=
 userlink=
 
+# unpack response file to arguments
+case "$1" in \@*)
+	exec xargs -a "${1#@}" "$0"
+esac
+
 for x ; do
     test "$cleared" || set -- ; cleared=1
 


### PR DESCRIPTION
Apparently, if the command line length exceeds 64 * 1024 characters, llvm tools will instead pack them into a response file and pass the path to that file prepended with `@` to the next invocation. 

So if a link command is too long, the `clang` call will call `ld.musl-clang` with a response file argument instead of the real command line arguments, which caused the script to completely skip all argument parsing. The `ld.lld` call below unpacks the response file correctly but because all argument parsing has been skipped over it will fail to link properly.

As far as I can tell there is no way to configure the maximum command line length before response files are used, and *theoretically* a system could configure a command line length limit so low that it wouldn't be possible to pass a long link command, so having support for response files is probably good anyway.

Documentation on how and [when](https://github.com/llvm/llvm-project/blob/fd7be0d2e9e2cb7d43c9cb97edbb36da59a5b595/llvm/lib/Support/Unix/Program.inc#L549) response files are used is sparse, so I've just implemented what's necessary for the single occurance I've seen and can reproduce with clang: The entire command line being replaced with a single response file argument.